### PR TITLE
Mark add-on EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@
 
 Book Manager and Automation (Sonarr for Ebooks).
 
+## Deprecation warning
+
+**This add-on is in a deprecated state!**
+
+The upstream Readarr project has been retired; meaning this add-on will not get
+updates anymore (and it is in a broken state already).
+
 ## About
 
 [Readarr] is an ebook and audiobook collection manager for Usenet and BitTorrent
@@ -107,7 +114,7 @@ SOFTWARE.
 [issue]: https://github.com/hassio-addons/addon-readarr/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-readarr.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
-[project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
+[project-stage-shield]: https://img.shields.io/badge/project%20stage-%20!%20DEPRECATED%20%20%20!-ff0000.svg
 [reddit]: https://reddit.com/r/homeassistant
 [releases-shield]: https://img.shields.io/github/release/hassio-addons/addon-readarr.svg
 [releases]: https://github.com/hassio-addons/addon-readarr/releases


### PR DESCRIPTION
# Proposed Changes

The usptream project is gone.

<img width="2114" height="1262" alt="CleanShot 2025-11-12 at 20 39 59@2x" src="https://github.com/user-attachments/assets/02b81519-63e8-4286-9143-96b25f83a93e" />

The project is broken right now, so there is no path forward but marking this one EOL.

../Frenck  

<p>
  <a href="https://www.linkedin.com/in/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/linkedin.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://youtube.com/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/youtube.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://bsky.app/profile/frenck.social"><img src="https://github.com/frenck/frenck/raw/main/images/bluesky.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://fosstodon.org/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/mastodon.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.instagram.com/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/instagram.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.threads.net/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/threads.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.facebook.com/frenck.dev/"><img src="https://github.com/frenck/frenck/raw/main/images/facebook.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://x.com/frenck"><img src="https://github.com/frenck/frenck/raw/main/images/x.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.tiktok.com/@frenck.nl"><img src="https://github.com/frenck/frenck/raw/main/images/tiktok.svg" width="18" height="18"></a>
</p>

Blogging my personal ramblings at <a href="https://frenck.dev">frenck.dev</a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice indicating the project is no longer actively maintained.
  * Updated project status badge to reflect deprecated status and note that the upstream project has been retired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->